### PR TITLE
Adding flag to skip Wiki validation.

### DIFF
--- a/src/main/java/org/jvnet/hudson/update_center/Plugin.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Plugin.java
@@ -100,7 +100,7 @@ public class Plugin {
         this.previous = previous;
         this.xmlReader = createXmlReader();
         this.pom = readPOM();
-        this.page = findPage(cpl);
+        this.page = cpl != null ? findPage(cpl) : null;
     }
 
     public Plugin(PluginHistory hpi, ConfluencePluginList cpl) throws IOException {
@@ -123,7 +123,7 @@ public class Plugin {
 
         this.xmlReader = createXmlReader();
         this.pom = readPOM();
-        this.page = findPage(cpl);
+        this.page = cpl != null ? findPage(cpl) : null;
     }
 
     public Plugin(HPI hpi, ConfluencePluginList cpl) throws IOException {


### PR DESCRIPTION
I would like to create an _Update Center_ for a private repository. Even if I change the plugin repository and recompile the **backend-update-center2**, the execution still fails because it validates the existence of a wiki page (wiki.jenkins-ci.org) - for every plugin - as an acceptance condition. This pull request adds a flag to skip wiki validation.
I could live with this change on my side only (though I would prefer not to maintain my own fork), but I've noticed a trend in the Jenkins community to move the docs away from wikis into github itself. So, maybe in the future the community could benefit from this simple change (and hopefully other people willing to set up their own UC).
