### PR TITLE
Don't allow plugins without wiki pages into LTS UCs, if the plugin release is new

### DIFF
--- a/src/main/java/org/jvnet/hudson/update_center/Main.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Main.java
@@ -293,9 +293,12 @@ public class Main {
                     if (actualUrl.isEmpty()) {
                         // When building older Update Centres (e.g. LTS releases), there will be a number of plugins which
                         // do not have wiki pages, even if the latest versions of those plugins *do* have wiki pages.
-                        // So here we keep the old behaviour: plugins without wiki pages are still kept.
+                        //
+                        // To allow for this, when building a capped UC, plugins without wiki pages will be permitted.
+                        // However, newly hosted plugins should know better, and *will* be excluded if missing a wiki URL.
+                        //
                         // This behaviour can be removed once we no longer generate UC files for LTS 1.596.x and older
-                        if (isVersionCappedRepository) {
+                        if (isVersionCappedRepository && hpi.latest().getTimestamp() < 1475280000000L /*2016-10-01*/) {
                             System.out.println(String.format("=> Keeping %s despite unknown/missing wiki URL: \"%s\"",
                                     hpi.artifactId, givenUrl));
                         } else {


### PR DESCRIPTION
If we're building a version-capped UC file, we now only include plugins without a wiki page if they were released before the wiki page rule came into force.

This would have fixed problems like the [Kubernetes plugins](https://issues.jenkins-ci.org/browse/HOSTING-113) showing up in the LTS UC, but not the latest UC (and therefore having no downloads on updates.jenkins.io), and also the gerrit-verify-status-reporter plugin from today.

So far in 2016, there have been releases of 8 plugins without valid wiki URLs, which are currently appearing in LTS UCs.  I've kept the existing behaviour for them, and set the cut-off time to October 2016 — this means that any plugins without a wiki page released from now onwards will not appear in the LTS UC.
