### PR TITLE
Optimize execution

### DIFF
--- a/src/main/java/org/jvnet/hudson/update_center/Main.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Main.java
@@ -272,7 +272,7 @@ public class Main {
         if (maxPlugins!=null)
             repo = new TruncatedMavenRepository(repo,maxPlugins);
         if (capPlugin !=null || getCapCore()!=null) {
-            VersionNumber vp = capPlugin==null ? ANY_VERSION : new VersionNumber(capPlugin);
+            VersionNumber vp = capPlugin==null ? null : new VersionNumber(capPlugin);
             VersionNumber vc = getCapCore()==null ? ANY_VERSION : new VersionNumber(getCapCore());
             repo = new VersionCappedMavenRepository(repo, vp, vc);
         }

--- a/src/main/java/org/jvnet/hudson/update_center/Main.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Main.java
@@ -271,15 +271,15 @@ public class Main {
         MavenRepository repo = DefaultMavenRepositoryBuilder.createStandardInstance();
         if (maxPlugins!=null)
             repo = new TruncatedMavenRepository(repo,maxPlugins);
+        if (experimentalOnly)
+            repo = new AlphaBetaOnlyRepository(repo,false);
+        if (noExperimental)
+            repo = new AlphaBetaOnlyRepository(repo,true);
         if (capPlugin !=null || getCapCore()!=null) {
             VersionNumber vp = capPlugin==null ? null : new VersionNumber(capPlugin);
             VersionNumber vc = getCapCore()==null ? ANY_VERSION : new VersionNumber(getCapCore());
             repo = new VersionCappedMavenRepository(repo, vp, vc);
         }
-        if (experimentalOnly)
-            repo = new AlphaBetaOnlyRepository(repo,false);
-        if (noExperimental)
-            repo = new AlphaBetaOnlyRepository(repo,true);
         return repo;
     }
 

--- a/src/main/java/org/jvnet/hudson/update_center/VersionCappedMavenRepository.java
+++ b/src/main/java/org/jvnet/hudson/update_center/VersionCappedMavenRepository.java
@@ -9,8 +9,10 @@ import org.sonatype.nexus.index.context.UnsupportedExistingLuceneIndexException;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 
@@ -49,24 +51,38 @@ public class VersionCappedMavenRepository extends MavenRepository {
     @Override
     public Collection<PluginHistory> listHudsonPlugins() throws PlexusContainerException, ComponentLookupException, IOException, UnsupportedExistingLuceneIndexException, AbstractArtifactResolutionException {
         Collection<PluginHistory> r = base.listHudsonPlugins();
+
         for (Iterator<PluginHistory> jtr = r.iterator(); jtr.hasNext();) {
             PluginHistory h = jtr.next();
+
+
+            Map<VersionNumber, HPI> versionNumberHPIMap = new TreeMap<>(VersionNumber.DESCENDING);
 
             for (Iterator<Entry<VersionNumber, HPI>> itr = h.artifacts.entrySet().iterator(); itr.hasNext();) {
                 Entry<VersionNumber, HPI> e =  itr.next();
                 if (capPlugin == null) {
                     // no cap
+                    versionNumberHPIMap.put(e.getKey(), e.getValue());
+                    if (versionNumberHPIMap.size() >= 2) {
+                        break;
+                    }
                     continue;
                 }
                 try {
                     VersionNumber v = new VersionNumber(e.getValue().getRequiredJenkinsVersion());
-                    if (v.compareTo(capPlugin)<=0)
+                    if (v.compareTo(capPlugin)<=0) {
+                        versionNumberHPIMap.put(e.getKey(), e.getValue());
+                        if (versionNumberHPIMap.size() >= 2) {
+                            break;
+                        }
                         continue;
+                    }
                 } catch (IOException x) {
                     x.printStackTrace();
                 }
-                itr.remove();
             }
+
+            h.artifacts.entrySet().retainAll(versionNumberHPIMap.entrySet());
 
             if (h.artifacts.isEmpty())
                 jtr.remove();

--- a/src/main/java/org/jvnet/hudson/update_center/VersionCappedMavenRepository.java
+++ b/src/main/java/org/jvnet/hudson/update_center/VersionCappedMavenRepository.java
@@ -54,6 +54,10 @@ public class VersionCappedMavenRepository extends MavenRepository {
 
             for (Iterator<Entry<VersionNumber, HPI>> itr = h.artifacts.entrySet().iterator(); itr.hasNext();) {
                 Entry<VersionNumber, HPI> e =  itr.next();
+                if (capPlugin == null) {
+                    // no cap
+                    continue;
+                }
                 try {
                     VersionNumber v = new VersionNumber(e.getValue().getRequiredJenkinsVersion());
                     if (v.compareTo(capPlugin)<=0)


### PR DESCRIPTION
I noticed extreme amounts of traffic when building an update site locally, even with the minimal possible output (`-skip-release-history` set, `-www-download` or `-download` not set).

Sure, there's `-maxPlugins`, but I wanted the full output.

Turns out the update center build…
- downloads all plugin HPIs to compare to the version cap, even if that is undefined (i.e. `999.999`).
- downloads all plugin HPIs to find the two with the newest versions for further use.

Both are unnecessary, and optimizing them away result in a good reduction in traffic and disk space use in the local Maven repository if `-cap` isn't set.

Also remove a check nobody cares about related to when an artifact was created -- there's maintenance/stable branches, so that check seems invalid even if anyone cared.