### PR TITLE
Symlink the mapping file to the top level directory

### DIFF
--- a/site/generate.sh
+++ b/site/generate.sh
@@ -102,7 +102,7 @@ ln -sf ../updates ./www2/current/updates
 # generate symlinks to retain compatibility with past layout and make Apache index useful
 pushd www2
     ln -s stable-$lastLTS stable
-    for f in latest latestCore.txt release-history.json update-center.*; do
+    for f in latest latestCore.txt plugin-documentation-urls.json release-history.json update-center.*; do
         ln -s current/$f .
     done
 


### PR DESCRIPTION
https://updates.jenkins-ci.org/current/plugin-documentation-urls.json exists.
https://updates.jenkins-ci.org/plugin-documentation-urls.json does not.

This fixes that.