### PR TITLE
Make timestamps in output TZ independent

### DIFF
--- a/src/main/java/org/jvnet/hudson/update_center/Plugin.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Plugin.java
@@ -248,7 +248,6 @@ public class Plugin {
         JSONObject json = latest.toJSON(artifactId);
 
         SimpleDateFormat fisheyeDateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'.00Z'", Locale.US);
-        fisheyeDateFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
         json.put("releaseTimestamp", fisheyeDateFormatter.format(latest.getTimestamp()));
         if (previous!=null) {
             json.put("previousVersion", previous.version);


### PR DESCRIPTION
`ZipEntry#getTime()` uses the default TZ to convert the zip date to a unix epoch:

https://docs.oracle.com/javase/8/docs/api/java/util/zip/ZipEntry.html#getTime--

>If the entry is read from a ZIP file or ZIP file formatted input stream, this is the last modification time from the date and time fields of the zip file entry. The default TimeZone is used to convert the standard MS-DOS formatted date and time to the epoch time.

So to have a consistent time stamp in the output independent of the current system TZ, we should not set a time zone for the date formatter.