### PR TITLE
Reference plugins.jenkins.io on release history

### DIFF
--- a/src/main/java/org/jvnet/hudson/update_center/Main.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Main.java
@@ -409,6 +409,7 @@ public class Main {
                     o.put("gav", h.artifact.groupId+':'+h.artifact.artifactId+':'+h.artifact.version);
                     o.put("timestamp", h.getTimestamp());
                     o.put("wiki", plugin.getPluginUrl());
+                    o.put("url", "https://plugins.jenkins.io/" + h.artifact.artifactId);
 
                     System.out.println("\t" + title + ":" + h.version);
                 } catch (IOException e) {


### PR DESCRIPTION
Will need a corresponding change downstream to link to the plugins site instead of the wiki: https://github.com/jenkins-infra/jenkins.io/pull/736

I added this as a new element as I don't know who might be using this.