### PR TITLE
Add Jenkinsfile for PR builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,26 @@
+#!groovy
+
+properties([
+        buildDiscarder(logRotator(numToKeepStr: '10', artifactNumToKeepStr: '2')),
+])
+
+node('linux') {
+    stage('Prepare') {
+        deleteDir()
+        checkout scm
+    }
+
+    stage('Generate') {
+        withEnv([
+                "PATH+MVN=${tool 'mvn'}/bin",
+                "JAVA_HOME=${tool 'jdk8'}",
+                "PATH+JAVA=${tool 'jdk8'}/bin"
+        ]) {
+            sh 'mvn -e clean verify'
+        }
+    }
+
+    stage('Archive') {
+        archive 'target/surefire-reports/*-output.txt'
+    }
+}


### PR DESCRIPTION
UNTESTED

Assumes https://github.com/jenkins-infra/backend-update-center2/pull/120 merged.

@rtyler WDYT? Or is the disk space requirement for the local Maven repo making this useless? Note that https://github.com/jenkins-infra/backend-update-center2/pull/115 could improve the situation.

Worst case we'll just build the generator, but not run it, in PRs.