### PR TITLE
Add log message when a warning does not apply to a plugin version

### DIFF
--- a/src/test/java/org/jvnet/hudson/update_center/WarningsTest.java
+++ b/src/test/java/org/jvnet/hudson/update_center/WarningsTest.java
@@ -93,6 +93,8 @@ public class WarningsTest {
                     versions.replace(p, true);
                     // written to target/surefire-reports/org.jvnet.hudson.update_center.WarningsTest-output.txt
                     System.out.println("Warning " + warning.id + " matches " + gav);
+                } else {
+                    System.out.println("Warning " + warning.id + " does NOT match " + gav);
                 }
             }
         }


### PR DESCRIPTION
This extends `target/surefire-reports/org.jvnet.hudson.update_center.WarningsTest-output.txt` with a list of plugin versions that don't match a certain version. This will make it easier to confirm that we actually match everything we intended to match (it's typically a shorter list than versions that match).