### PR TITLE
[WEBSITE-332] Replace 'scm' host name by full browsable jenkinsci GitHub URL

### DIFF
--- a/src/main/java/org/jvnet/hudson/update_center/Plugin.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Plugin.java
@@ -358,14 +358,15 @@ public class Plugin {
                 // Last resort: check whether a ${artifactId}-plugin repo in jenkinsci exists, if so, use that
                 scm = "https://github.com/jenkinsci/" + artifactId + "-plugin";
                 System.out.println("** Falling back to default repo for " + artifactId + ": " + scm);
+
+                String checkedScm = scm;
+                // Check whether the fallback repo actually exists, if not, don't publish the repo name
+                scm = requireGitHubRepoExistence(scm);
+                if (scm == null) {
+                    System.out.println("** Repository does not actually exist: " + checkedScm);
+                }
             }
 
-            String checkedScm = scm;
-            // Check whether the specified repo actually exists, if not, don't publish the repo name
-            scm = requireGitHubRepoExistence(scm);
-            if (scm == null) {
-                System.out.println("** Repository does not actually exist: " + checkedScm);
-            }
             return scm;
         }
         return null;


### PR DESCRIPTION
**Do not merge** before people had some time to speak up and point us to consumers of the `scm` entry in the `update-center.json`, and we've adapted https://github.com/jenkins-infra/backend-jenkins-plugin-info-plugin to handle the new format.

Context:
https://issues.jenkins-ci.org/browse/WEBSITE-332
http://lists.jenkins-ci.org/pipermail/jenkins-infra/2017-March/001058.html

This tries to determine the SCM URL from the POM or parent POM's `scm/url` or `scm/developerConnection` elements. URLs pointing to old SVN repos are discarded, GitHub.com/jenkinsci URLs are rewritten to https:// (especially if SSH connection strings).

1100+ plugins have SCM URLs after this change (untested, some may be wrong), ~100 cannot be determined or only have known obsolete URLs, and another ~110 have URLs outside the Jenkins community (e.g. Bitbucket).