### PR TITLE
Exclude renamed delphix-plugin.

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -26,6 +26,7 @@ copyarchiver                     # superseded by ArtifactDeployer Plugin  -- htt
 cppunit                          # Incompatible with Hudson 1.355+ and superseded by xUnit Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/CppUnit+Plugin
 create-fingerprint-plugin        # renamed to create-fingerprint
 datadog-build-reporter           # renamed to datadog
+delphix-plugin                   # renamed to delphix
 description-column               # renamed to description-column-plugin
 dockerhub                        # removal requested by teilo, superceded by dockerhub-notification
 drools                           # deprecated


### PR DESCRIPTION
Duplicate plugin brought into the UC after the wiki page requirement was dropped; artifact ID was changed after version 1.0.0: https://github.com/jenkinsci/delphix-plugin/commit/d80a744d8f6e2d8edf3f9a3f2e5009bf34455ca0

