### PR TITLE
Don't skip plugin documentation URL gathering after POM access optimi…

### DIFF
--- a/src/main/java/org/jvnet/hudson/update_center/Plugin.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Plugin.java
@@ -162,7 +162,7 @@ public class Plugin {
         String url = URL_OVERRIDES.getProperty(artifactId);
 
         // Otherwise read the wiki URL from the POM, if any
-        if (url == null && pom != null) {
+        if (url == null) {
             url = selectSingleValue(getPom(), "/project/url");
         }
 


### PR DESCRIPTION
…zation

---

`pom` is generally `null` at this point due to the optimization in #124 item 1. So ignore that.

While this could throw a new IOException, the calling code is within a try block, so should handle this.