### PR TITLE
Remove ancient baselines

### DIFF
--- a/site/generate.sh
+++ b/site/generate.sh
@@ -4,7 +4,7 @@
 # Used later for rsyncing updates
 UPDATES_SITE="updates.jenkins.io"
 RSYNC_USER="www-data"
-declare -a BASELINES=( 1.554 1.565 1.580 1.596 1.609 1.625 1.642 1.651 2.7 2.19 2.32 )
+declare -a BASELINES=( 1.609 1.625 1.642 1.651 2.7 2.19 2.32 )
 
 umask
 


### PR DESCRIPTION
@olivergondza @rtyler @orrc @batmat @oleg-nenashev

 Per https://github.com/jenkins-infra/backend-update-center2/pull/114#issuecomment-283852491:

> We should probably consider removing the update sites predating 2.0. It'll be a year (which is what we originally started with in dd88dc7 -- and 2d67efa rotated out the oldest one).
> 
> Then I took over, and just didn't bother doing that for reasons now unknown to me…

Oliver would like to keep 1.609 around for a while longer, so accommodate that.

Related: Release dates via http://jenkins-ci.org/changelog-stable

* *1.554.3 (2014/06/30)*
* *1.565.3 (2014/10/01)*
* *1.580.3 (2015/01/27)*
* *1.596.3 (2015/05/20)*
* 1.609.3 (2015/09/02)
* 1.625.3 (2015/12/09)
* 1.642.4 (2016/03/31)
* 1.651.3 (2016/06/08)
* 2.7.4 (2016-09-08)