### PR TITLE
Ignore these until launch date

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -183,3 +183,35 @@ hello-world-scala
 
 # Suppress sse-gateway 1.14  - it has unsatisfied dependency on pubsub-light 1.5
 sse-gateway-1.14
+
+# Temporary for blue ocean 1.0.0 release - to remove on 5th April 2017
+blueocean-1.0.0
+blueocean-commons-1.0.0
+blueocean-config-1.0.0
+blueocean-dashboard-1.0.0
+blueocean-events-1.0.0
+blueocean-git-pipeline-1.0.0
+blueocean-github-pipeline-1.0.0
+blueocean-i18n-1.0.0
+blueocean-jwt-1.0.0
+blueocean-personalization-1.0.0
+blueocean-pipeline-api-impl-1.0.0
+blueocean-rest-1.0.0
+blueocean-rest-impl-1.0.0
+blueocean-web-1.0.0
+
+# Temporary for blue ocean 1.0.1 release (just in case need another) - to remove on 5th April 2017
+blueocean-1.0.1
+blueocean-commons-1.0.1
+blueocean-config-1.0.1
+blueocean-dashboard-1.0.1
+blueocean-events-1.0.1
+blueocean-git-pipeline-1.0.1
+blueocean-github-pipeline-1.0.1
+blueocean-i18n-1.0.1
+blueocean-jwt-1.0.1
+blueocean-personalization-1.0.1
+blueocean-pipeline-api-impl-1.0.1
+blueocean-rest-1.0.1
+blueocean-rest-impl-1.0.1
+blueocean-web-1.0.1


### PR DESCRIPTION
Please review @vivek @i386 @rtyler 

This ignores 1.0.0/1 from UC temporarily as discussed - artifacts need to match those in https://github.com/jenkinsci/blueocean-plugin (please cross check vivek and james). 

If this is merged, there will have to be a follow on PR to remove them on the 5th April (US time/date). 

