### PR TITLE
Restore distribution of app-detector

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -187,7 +187,6 @@ sse-gateway-1.14
 
 # https://jenkins.io/security/advisory/2017-04-10/
 AdaptivePlugin                # SECURITY-457
-app-detector                  # SECURITY-494
 artifactdeployer              # SECURITY-294
 build-flow-plugin             # SECURITY-293
 cas-plugin                    # SECURITY-488

--- a/src/main/resources/warnings.json
+++ b/src/main/resources/warnings.json
@@ -756,6 +756,7 @@
     "url": "https://jenkins.io/security/advisory/2017-04-10/",
     "versions": [
       {
+        "lastVersion": "1.0.1",
         "pattern": "1[.]0[.][01](|[-].*)"
       }
     ]

--- a/src/main/resources/warnings.json
+++ b/src/main/resources/warnings.json
@@ -756,6 +756,18 @@
     "url": "https://jenkins.io/security/advisory/2017-04-10/",
     "versions": [
       {
+        "pattern": "1[.]0[.][01](|[-].*)"
+      }
+    ]
+  },
+  {
+    "id": "SECURITY-494-v2",
+    "type": "plugin",
+    "name": "app-detector",
+    "message": "Arbitrary code execution vulnerability in rare circumstances",
+    "url": "https://jenkins.io/security/advisory/2017-04-10/",
+    "versions": [
+      {
         "pattern": ".*"
       }
     ]


### PR DESCRIPTION
The permissions issue has been resolved in 1.0.2, but issue a new
warning for the Administer/Run Scripts issue that's still present.

---

CC @justice3120 Sorry for the delay.