### PR TITLE
Restore BuildGraph-View Plugin

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -209,7 +209,6 @@ tcl                           # SECURITY-379
 youtrack-plugin               # SECURITY-462
 
 # These plugins depend on one or more plugins blacklisted due to the 2017-04-10 advisory
-buildgraph-view               # depends on build-flow-plugin
 build-flow-extensions-plugin  # depends on build-flow-plugin, buildgraph-view
 build-flow-test-aggregator    # depends on build-flow-plugin
 build-flow-toolbox-plugin     # depends on build-flow-plugin


### PR DESCRIPTION
With BuildGraph-View-1.6 version dependency with Build-Flow-Plugin marked as optional.
Now with latest version there is no mandate dependency,

@daniel-beck 
Let me know whether this suffix to restore the plugin.

Thanks