### PR TITLE
fixed SECURITY-496, SplunkMessageStep was disabled in 1.4.3

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -203,7 +203,6 @@ reactor-plugin                # SECURITY-487
 script-scm                    # SECURITY-461
 scriptler                     # SECURITY-367 etc.
 scripttrigger                 # SECURITY-456
-splunk-devops-extend          # SECURITY-496
 svn-tag                       # SECURITY-298
 tcl                           # SECURITY-379
 youtrack-plugin               # SECURITY-462

--- a/src/main/resources/warnings.json
+++ b/src/main/resources/warnings.json
@@ -780,7 +780,8 @@
     "url": "https://jenkins.io/security/advisory/2017-04-10/",
     "versions": [
       {
-        "pattern": ".*"
+        "lastVersion": "1.4.3",
+        "pattern": "1[.][01234](|[.-].*)"
       }
     ]
   }


### PR DESCRIPTION
https://github.com/jenkinsci/splunk-devops-plugin/commit/8a845a79031af6ed8c4cc25db399363f9c34188d\#diff-d0d9c36aca7861d4559fd59371c1c95b, the step will throw UnsupportedOperationException