### PR TITLE
Add option to filter for stable core releases

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ node('linux') {
             sh 'java -jar target/update-center2-*-bin*/update-center2-*.jar' +
                     ' -id default -connectionCheckUrl http://www.google.com/' +
                     ' -no-experimental -skip-release-history' +
-                    ' -www ./output -cap 2.32.999 -capCore 2.32.999'
+                    ' -www ./output -cap 2.32.999 -stableCore'
         }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ node('linux') {
             sh 'java -jar target/update-center2-*-bin*/update-center2-*.jar' +
                     ' -id default -connectionCheckUrl http://www.google.com/' +
                     ' -no-experimental -skip-release-history' +
-                    ' -www ./output -cap 2.32.999 -stableCore'
+                    ' -www ./output -cap 2.32.999 -capCore 2.999 -stableCore'
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>version-number</artifactId>
-      <version>1.1</version>
+      <version>1.4</version>
     </dependency>
     <dependency>
       <groupId>bouncycastle</groupId>

--- a/site/generate.sh
+++ b/site/generate.sh
@@ -57,7 +57,7 @@ for v in ${BASELINES[@]}; do
     ln -sf ../updates ./www2/$v/updates
 
     # for LTS
-    generate -no-experimental -skip-release-history -www ./www2/stable-$v -cap $v.999 -capCore ${BASELINES[${#BASELINES[@]}-1]}.999
+    generate -no-experimental -skip-release-history -www ./www2/stable-$v -cap $v.999 -stableCore
     sanity-check ./www2/stable-$v
     ln -sf ../updates ./www2/stable-$v/updates
     lastLTS=$v

--- a/site/generate.sh
+++ b/site/generate.sh
@@ -57,7 +57,7 @@ for v in ${BASELINES[@]}; do
     ln -sf ../updates ./www2/$v/updates
 
     # for LTS
-    generate -no-experimental -skip-release-history -www ./www2/stable-$v -cap $v.999 -stableCore
+    generate -no-experimental -skip-release-history -www ./www2/stable-$v -cap $v.999 -capCore 2.999 -stableCore
     sanity-check ./www2/stable-$v
     ln -sf ../updates ./www2/stable-$v/updates
     lastLTS=$v

--- a/src/main/java/org/jvnet/hudson/update_center/Main.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Main.java
@@ -132,6 +132,9 @@ public class Main {
     @Option(name="-capCore",usage="Cap the version number and only core that's compatible with. Defaults to -cap")
     public String capCore = null;
 
+    @Option(name="-stableCore", usage="Limit core releases to stable (LTS) releases (those with three component version numbers)")
+    public boolean stableCore;
+
     @Option(name="-pluginCount.txt",usage="Report a number of plugins in a simple text file")
     public File pluginCountTxt = null;
 
@@ -277,6 +280,9 @@ public class Main {
             repo = new AlphaBetaOnlyRepository(repo,false);
         if (noExperimental)
             repo = new AlphaBetaOnlyRepository(repo,true);
+        if (stableCore) {
+            repo = new StableMavenRepository(repo);
+        }
         if (capPlugin !=null || getCapCore()!=null) {
             VersionNumber vp = capPlugin==null ? null : new VersionNumber(capPlugin);
             VersionNumber vc = getCapCore()==null ? ANY_VERSION : new VersionNumber(getCapCore());

--- a/src/main/java/org/jvnet/hudson/update_center/StableMavenRepository.java
+++ b/src/main/java/org/jvnet/hudson/update_center/StableMavenRepository.java
@@ -1,0 +1,52 @@
+package org.jvnet.hudson.update_center;
+
+import hudson.util.VersionNumber;
+import org.apache.maven.artifact.resolver.AbstractArtifactResolutionException;
+import org.codehaus.plexus.PlexusContainerException;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.sonatype.nexus.index.ArtifactInfo;
+import org.sonatype.nexus.index.context.UnsupportedExistingLuceneIndexException;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.TreeMap;
+
+/**
+ * Delegating {@link MavenRepository} to limit core releases to those with LTS version numbers.
+ *
+ * @author Daniel Beck
+ */
+public class StableMavenRepository extends MavenRepository {
+
+    public StableMavenRepository(MavenRepository base) {
+        setBaseRepository(base);
+    }
+
+    @Override
+    public TreeMap<VersionNumber, HudsonWar> getHudsonWar() throws IOException, AbstractArtifactResolutionException {
+        TreeMap<VersionNumber, HudsonWar> releases = base.getHudsonWar();
+
+        releases.keySet().retainAll(Arrays.asList(releases.keySet().stream().filter(it -> it.getDigitAt(2) != -1).toArray()));
+
+        return releases;
+    }
+
+    @Override
+    protected File resolve(ArtifactInfo a, String type, String classifier) throws AbstractArtifactResolutionException {
+        return base.resolve(a, type, classifier);
+    }
+
+    @Override
+    public Collection<PluginHistory> listHudsonPlugins() throws PlexusContainerException, ComponentLookupException, IOException, UnsupportedExistingLuceneIndexException, AbstractArtifactResolutionException {
+        return base.listHudsonPlugins();
+    }
+
+    private boolean isStableRelease() {
+        return false;
+    }
+}


### PR DESCRIPTION
Prevents serving regular weeklies to LTS users like earlier today due to premature merge of https://github.com/jenkins-infra/backend-update-center2/pull/144

Preparation for https://issues.jenkins-ci.org/browse/INFRA-1193

@olivergondza  @rtyler 