### PR TITLE
Translation Assistance Plugin is practically unusable

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -114,6 +114,7 @@ tepco-epuw                       # unused? -- https://wiki.jenkins-ci.org/displa
 TestExecuter                     # renamed to selected-tests-executor
 testflight                       # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Testflight+Plugin
 TestResultsAnalyzer              # renamed to test-results-analyzer
+translation                      # The server handling submitted translations has been shut down
 tusarnotifier                    # superseded by DTKit Plugin with automatic migration -- https://wiki.jenkins-ci.org/display/JENKINS/TusarNotifier
 uithemes                         # removal requested by tfennelly
 upload-artifacts-to-nexus        # renamed, see https://issues.jenkins-ci.org/browse/HOSTING-41?focusedCommentId=250383&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-250383


### PR DESCRIPTION
I think this plugin should be blocked from Updates Centers. Why?

1. The main feature of this plugin is not longer usable. Announced in the [plugin website](https://wiki.jenkins-ci.org/display/JENKINS/Translation+Assistance+Plugin)
1. Has this plugin a maintainer?
1. This plugin **is forcing** to keep a specific HTML markup in all Jenkins views: `var f = document.getElementById('footer');`
```
<script>var footer = document.getElementById('l10n-footer');
    var f = document.getElementById('footer');
    f.insertBefore(footer, f.firstChild);
    footer.style.display = "block";

    var translation = {}; 
    translation.bundles = "";
    translation.detectedLocale = "es";

    function showTranslationDialog() {
      if(!translation.launchDialog)
        loadScript("/jenkins/plugin/translation/dialog.js");
      else
        translation.launchDialog();
      return false; 
    }
</script>
```

The proposal would be to block this plugin and avoid [this code](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/lib/layout/layout.jelly#L275).

@reviewbybees