### PR TITLE
Add 2.60 update site

### DIFF
--- a/site/generate.sh
+++ b/site/generate.sh
@@ -4,7 +4,7 @@
 # Used later for rsyncing updates
 UPDATES_SITE="updates.jenkins.io"
 RSYNC_USER="www-data"
-declare -a BASELINES=( 1.609 1.625 1.642 1.651 2.7 2.19 2.32 2.46 )
+declare -a BASELINES=( 1.609 1.625 1.642 1.651 2.7 2.19 2.32 2.46 2.60 )
 
 umask
 


### PR DESCRIPTION
Basically #144 again, but #145 now means that a premature merge of this (should me mergeable at any time) will not result in invalid LTS update sites offering the 2.60 weekly release.

The only effect until 2.60.1 is out will result in an additional layer for weekly releases, where 2.46 < X ≤ 2.60 will be offered fewer incompatible plugins (as we're still offering incompatible plugin updates rather than outdated plugins between LTS baselines) -- i.e. none that require 2.61+.

@olivergondza 