### PR TITLE
The diskcheck plugin is literally the worst and should be eradicated.

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -28,6 +28,7 @@ create-fingerprint-plugin        # renamed to create-fingerprint
 datadog-build-reporter           # renamed to datadog
 delphix-plugin                   # renamed to delphix
 description-column               # renamed to description-column-plugin
+diskcheck                        # This plugin seriously calls System.exit. It is terrible and should not exist. https://github.com/jenkinsci/diskcheck-plugin/blob/master/src/main/java/org/jenkinsci/plugin/Diskcheck.java#L121. Seriously.
 dockerhub                        # removal requested by teilo, superceded by dockerhub-notification
 drools                           # deprecated
 emotional-hudson                 # Superseded by Emotional Jenkins -- https://wiki.jenkins-ci.org/display/JENKINS/Emotional+Hudson+Plugin


### PR DESCRIPTION
Let me explain a bit. 

https://github.com/jenkinsci/diskcheck-plugin/blob/master/src/main/java/org/jenkinsci/plugin/Diskcheck.java#L121

No, really. It calls `System.exit(0)`. I've talked to multiple users *today* (just today!) who have installed it and then poof, their masters go down. That...is not acceptable. So please, dear god, get rid of it. Forever.

cc @daniel-beck @rtyler 