### PR TITLE
Remove mber plugin from distribution

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -69,6 +69,7 @@ lechat                           # renamed to Kata which was discontinued -- htt
 liverebel-deploy                 # only worked with obsolete releases -- https://wiki.jenkins-ci.org/display/JENKINS/LiveRebel+Plugin
 m2-extra-steps                   # part of core functionality since 1.433 -- https://wiki.jenkins-ci.org/display/JENKINS/M2+Extra+Steps+Plugin
 mansion-cloud                    # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Cloud+Connector+Plugin
+mber                             # service discontinued -- https://wiki.jenkins.io/display/JENKINS/Mber+Plugin
 mcap-eas-plugin                  # superseded by Relution Publisher (see https://github.com/mwaylabs/jenkins-mcap-eas-plugin)
 mogotest                         # deprecated: mogotest service no longer exists
 mypeople                         # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/MyPeople+Plugin


### PR DESCRIPTION
This service appears to have been shut down:
https://wiki.jenkins.io/display/JENKINS/Mber+Plugin

CC @firepub-pfreeman @onefrankguy