### PR TITLE
[JENKINS-45126] Remove Gradle plugin 1.27

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -132,6 +132,7 @@ zubhium                          # service discontinued -- https://wiki.jenkins-
 active-directory-2.1      # JENKINS-42739
 BlameSubversion-1.121     # big number but not the latest release
 fortify-on-demand-uploader-1.0 # removal requested by Ryan Black, plugin wasn't ready for release
+gradle-1.27               # JENKINS-45126
 matrix-project-1.2.1      # also INFRA-250
 matrix-project-1.4.1      # this specific version is excluded for INFRA-250
 rebuild-1.2               # release troubles.. skip these


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-45126

Something went wrong with the 1.27 release.

CC @wolfs 