### PR TITLE
A bad deploy is bad

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -222,14 +222,11 @@ plumber
 
 # A bad deploy, and maven multi module and no staging means bad bad time
 blueocean-rest-impl-1.1.3 
-blueocean-pipeline-editor-1.1.3
 blueocean-git-pipeline-1.1.3
 blueocean-config-1.1.3
-blueocean-autofavorite-1.1.3
 blueocean-personalization-1.1.3
 blueocean-rest-1.1.3
 blueocean-i18n-1.1.3
-blueocean-display-url-1.1.3
 blueocean-events-1.1.3
 blueocean-commons-1.1.3
 blueocean-web-1.1.3

--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -219,3 +219,22 @@ xtrigger                      # depends on scripttrigger
 groovy-choice-parameter
 groovy-script-scheduler
 plumber
+
+# A bad deploy, and maven multi module and no staging means bad bad time
+blueocean-rest-impl-1.1.3 
+blueocean-pipeline-editor-1.1.3
+blueocean-git-pipeline-1.1.3
+blueocean-config-1.1.3
+blueocean-autofavorite-1.1.3
+blueocean-personalization-1.1.3
+blueocean-rest-1.1.3
+blueocean-i18n-1.1.3
+blueocean-display-url-1.1.3
+blueocean-events-1.1.3
+blueocean-commons-1.1.3
+blueocean-web-1.1.3
+blueocean-pipeline-api-impl-1.1.3
+blueocean-dashboard-1.1.3
+blueocean-jwt-1.1.3
+blueocean-github-pipeline-1.1.3
+


### PR DESCRIPTION
cc @vivek @i386

What happened was a partial deploy - it failed during a release:perform in maven due to a full disk (no warning) - leaving it in a bad state. 1.1.4 will go out to replace it, but we don't know of another way to undo the damage
