### PR TITLE
[INFRA-1266] Better ln logging

### DIFF
--- a/src/main/java/org/jvnet/hudson/update_center/Main.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Main.java
@@ -378,8 +378,10 @@ public class Main {
 
         ProcessBuilder pb = new ProcessBuilder();
         pb.command("ln","-f", src.getAbsolutePath(), dst.getAbsolutePath());
-        if (pb.start().waitFor()!=0)
-            throw new IOException("ln failed");
+        Process p = pb.start();
+        if (p.waitFor()!=0)
+            throw new IOException("'ln -f " + src.getAbsolutePath() + " " +dst.getAbsolutePath() +
+                    "' failed with code " + p.exitValue() + "\nError: " + IOUtils.toString(p.getErrorStream()) + "\nOutput: " + IOUtils.toString(p.getInputStream()));
 
     }
 


### PR DESCRIPTION
Output before:

	java.io.IOException: ln failed
		at org.jvnet.hudson.update_center.Main.stage(Main.java:382)
		at org.jvnet.hudson.update_center.Main.buildPlugins(Main.java:326)
		at org.jvnet.hudson.update_center.Main.buildUpdateCenterJson(Main.java:248)
		at org.jvnet.hudson.update_center.Main.run(Main.java:198)
		at org.jvnet.hudson.update_center.Main.run(Main.java:168)
		at org.jvnet.hudson.update_center.Main.main(Main.java:155)

Output now:

	Exception in thread "main" java.io.IOException: 'ln -f /Users/danielbeck/.m2/repository/org/jenkins-ci/main/jenkins-war/2.68/jenkins-war-2.68.war /Users/danielbeck/Repositories/jenkins-infra/backend-update-center2.git/./download/war/2.68/jenkins.war' failed with code 1
	Error: ln: illegal option -- b
	usage: ln [-Ffhinsv] source_file [target_file]
	       ln [-Ffhinsv] source_file ... target_dir
	       link source_file target_file

	Output: 
	        at org.jvnet.hudson.update_center.Main.stage(Main.java:384)
	        at org.jvnet.hudson.update_center.Main.buildCore(Main.java:502)
	        at org.jvnet.hudson.update_center.Main.buildUpdateCenterJson(Main.java:244)
	        at org.jvnet.hudson.update_center.Main.run(Main.java:198)
	        at org.jvnet.hudson.update_center.Main.run(Main.java:168)
	        at org.jvnet.hudson.update_center.Main.main(Main.java:155)
