### PR TITLE
Ignore kubernetes-pipeline plugins 1.3

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -127,6 +127,9 @@ zaproxy                          # superseded by zap -- https://wiki.jenkins-ci.
 zaproxy-jenkins                  # renamed to zaproxy
 zubhium                          # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Zubhium+Plugin
 
+# while https://github.com/jenkinsci/kubernetes-pipeline-plugin/pull/31 is unmerged, disables updates sites
+kubernetes-pipeline-steps-1.3
+kubernetes-pipeline-devops-steps-1.3
 
 
 # specific releases

--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -130,7 +130,7 @@ zubhium                          # service discontinued -- https://wiki.jenkins-
 # while https://github.com/jenkinsci/kubernetes-pipeline-plugin/pull/31 is unmerged, disables updates sites
 kubernetes-pipeline-steps-1.3
 kubernetes-pipeline-devops-steps-1.3
-
+kubernetes-pipeline-aggregator-1.3
 
 # specific releases
 active-directory-2.1      # JENKINS-42739


### PR DESCRIPTION
https://github.com/jenkinsci/kubernetes-pipeline-plugin/pull/31 is a serious problem for anyone who has that plugin installed.

Unless Jenkins is configured with an HTTPS URL (which bypasses the mirror network), the redirect of the general update site URL to one of the mirrors will not work. Jenkins instances configured this way will neither receive update notifications, nor security warnings, unless that happens before the redirects are disabled. Especially for instances not restarting regularly, that's a major problem.

For an example, see recent comments to [JENKINS-38185](https://issues.jenkins-ci.org/browse/JENKINS-38185) from an affected user.

Therefore I propose to blacklist the affected release of the plugin (https://github.com/jenkinsci/kubernetes-pipeline-plugin/commit/d8940011fc930135a7cfa18eb1e64d8f5f75de49) until this is fixed to prevent more users from falling into this trap.

Please review @oleg-nenashev @rtyler

FYI/RFC plugin maintainers @iocanel @jstrachan @rawlingsj 