### PR TITLE
[JENKINS-46130] Remove delivery-pipeline-plugin-1.0.4

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -190,6 +190,9 @@ hello-world-scala
 # Suppress sse-gateway 1.14  - it has unsatisfied dependency on pubsub-light 1.5
 sse-gateway-1.14
 
+# JENKINS-46130
+delivery-pipeline-plugin-1.0.4
+
 # https://jenkins.io/security/advisory/2017-04-10/
 AdaptivePlugin                # SECURITY-457
 artifactdeployer              # SECURITY-294


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-46130

Maintainers are not re-releasing a completely broken 1.0.4, so it's time this is blacklisted. I expected that to just be fixed and the world to move on, but more than three weeks later, it's not.

Apparent maintainers: @tommysdk @Crasher-ua

@oleg-nenashev @rtyler @orrc @batmat 