### PR TITLE
scm-branch-pr-filter was renamed to scm-filter-branch-pr

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -101,6 +101,7 @@ sample                           # junk plugin; developer has been banned
 schedule-build-plugin            # renamed to schedule-build
 schedule-failed-builds           # superseded by Naginator Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Retry+Failed+Builds+Plugin
 scis-ad                          # deprecated
+scm-branch-pr-filter             # renamed shortly after publication for https://github.com/jenkins-infra/repository-permissions-updater/pull/459#issuecomment-334702817
 script-realm-extended            # fork of a plugin and has since been subsumed -- https://wiki.jenkins-ci.org/display/JENKINS/Script+Security+Realm+Extended
 secret                           # superseded by Credentials Binding Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Build+Secret+Plugin
 security-no-captcha              # Functionality integrated in Jenkins 1.416 -- https://wiki.jenkins-ci.org/display/JENKINS/Security+No+CAPTCHA


### PR DESCRIPTION
Downstream from https://github.com/jenkins-infra/repository-permissions-updater/pull/459 and https://github.com/jenkins-infra/repository-permissions-updater/pull/463 

@stephenc discovered a naming rule shortly after people started creating plugins it applies to. It was too late for @samrocketman's first release.

CC @slide and @orrc perhaps you could look out for these in HOSTING?