### PR TITLE
[WiP, NO_MERGE] [JENKINS-47364, JENKINS-47370] - Remove EnvInject 2.1.4 from Distribution

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -143,6 +143,7 @@ matrix-project-1.4.1      # this specific version is excluded for INFRA-250
 rebuild-1.2               # release troubles.. skip these
 rebuild-1.3               # ??
 ruby-runtime-0.13         # JENKINS-37353, JENKINS-37771 and JENKINS-38145
+envinject-2.1.4           # JENKINS-47364, JENKINS-47370
 
 # rogue releases with unknown source
 ez-templates-1.0.0


### PR DESCRIPTION
EnvInject 2.1.4 passed all tests, but there was a significant regression reported. I would prefer to depublish it for a while till I investigate the issue and come up with a better fix.

@reviewbybees @dwnusbaum @nfalco79