### PR TITLE
Limit supported releases from 10 to 7

### DIFF
--- a/site/generate.sh
+++ b/site/generate.sh
@@ -10,7 +10,7 @@ chmod +x jq || { echo "Failed to make jq executable" >&2 ; exit 1; }
 
 set -o pipefail
 
-RELEASES=$( curl 'https://repo.jenkins-ci.org/api/search/versions?g=org.jenkins-ci.main&a=jenkins-core&repos=releases&v=?.*.1' | ./jq --raw-output '.results[].version' | head -n 4 | sort --version-sort ) || { echo "Failed to retrieve list of releases" >&2 ; exit 1 ; }
+RELEASES=$( curl 'https://repo.jenkins-ci.org/api/search/versions?g=org.jenkins-ci.main&a=jenkins-core&repos=releases&v=?.*.1' | ./jq --raw-output '.results[].version' | head -n 7 | sort --version-sort ) || { echo "Failed to retrieve list of releases" >&2 ; exit 1 ; }
 
 set +o pipefail
 

--- a/site/generate.sh
+++ b/site/generate.sh
@@ -10,7 +10,7 @@ chmod +x jq || { echo "Failed to make jq executable" >&2 ; exit 1; }
 
 set -o pipefail
 
-RELEASES=$( curl 'https://repo.jenkins-ci.org/api/search/versions?g=org.jenkins-ci.main&a=jenkins-core&repos=releases&v=?.*.1' | ./jq --raw-output '.results[].version' | head -n 10 | sort --version-sort ) || { echo "Failed to retrieve list of releases" >&2 ; exit 1 ; }
+RELEASES=$( curl 'https://repo.jenkins-ci.org/api/search/versions?g=org.jenkins-ci.main&a=jenkins-core&repos=releases&v=?.*.1' | ./jq --raw-output '.results[].version' | head -n 4 | sort --version-sort ) || { echo "Failed to retrieve list of releases" >&2 ; exit 1 ; }
 
 set +o pipefail
 


### PR DESCRIPTION
I'm sick of waiting 40 minutes for this build to finish every time I release security updates.
Supporting ten release lines via the update sites is beyond ridiculous, nobody should be using Jenkins this old. Anything older than 2.46.2 is plain insane, so I'm being generous here: Four lines means an update once a year. That seems reasonable.