### PR TITLE
update claim plugin vulnerable version

### DIFF
--- a/src/main/resources/warnings.json
+++ b/src/main/resources/warnings.json
@@ -377,7 +377,8 @@
     "url": "https://jenkins.io/security/advisory/2017-04-10/",
     "versions": [
       {
-        "pattern": ".*"
+        "lastVersion": "2.9",
+        "pattern": "1[.].*(|[.-].*)|2[.][0-9].*(|[.-].*)"
       }
     ]
   },


### PR DESCRIPTION
I cannot close SECURITY-296 as I cannot see it myself. (I used JENKINS-43811 for that)
I edited https://wiki.jenkins.io/display/JENKINS/Script+Security+Support+in+Plugins with the information needed.
Please tell me if I need to do other things.