### PR TITLE
remove loadrunner from uc

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -66,6 +66,7 @@ kato                             # service discontinued -- https://wiki.jenkins-
 koji-plugin                      # renamed to koji
 kundo                            # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Kundo+Plugin
 lechat                           # renamed to Kata which was discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/LeChat+Plugin
+loadrunner                       # closed-source plugin, removal requested by plugin author
 liverebel-deploy                 # only worked with obsolete releases -- https://wiki.jenkins-ci.org/display/JENKINS/LiveRebel+Plugin
 m2-extra-steps                   # part of core functionality since 1.433 -- https://wiki.jenkins-ci.org/display/JENKINS/M2+Extra+Steps+Plugin
 mansion-cloud                    # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Cloud+Connector+Plugin


### PR DESCRIPTION
This closed-source plugin was accidentally uploaded and needs to be removed from UC.

Also see https://github.com/jenkins-infra/repository-permissions-updater/pull/506