### PR TITLE
Limit to five release lines

### DIFF
--- a/site/generate.sh
+++ b/site/generate.sh
@@ -10,7 +10,7 @@ chmod +x jq || { echo "Failed to make jq executable" >&2 ; exit 1; }
 
 set -o pipefail
 
-RELEASES=$( curl 'https://repo.jenkins-ci.org/api/search/versions?g=org.jenkins-ci.main&a=jenkins-core&repos=releases&v=?.*.1' | ./jq --raw-output '.results[].version' | head -n 7 | sort --version-sort ) || { echo "Failed to retrieve list of releases" >&2 ; exit 1 ; }
+RELEASES=$( curl 'https://repo.jenkins-ci.org/api/search/versions?g=org.jenkins-ci.main&a=jenkins-core&repos=releases&v=?.*.1' | ./jq --raw-output '.results[].version' | head -n 5 | sort --version-sort ) || { echo "Failed to retrieve list of releases" >&2 ; exit 1 ; }
 
 set +o pipefail
 


### PR DESCRIPTION
Followup to https://github.com/jenkins-infra/backend-update-center2/pull/168 based on the consensus reached there of going with five supported baselines starting with 2.89.x.

Today, we update sites for 2.73, 2.60, 2.46, 2.32, 2.19, 2.7, and 1.651.
Tomorrow, we will add 2.89, and rotate out 2.19, 2.7, and 1.651.