### PR TITLE
[SECURITY-294] Restore Artifact Deployer plugin distribution 

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -197,7 +197,6 @@ delivery-pipeline-plugin-1.0.4
 
 # https://jenkins.io/security/advisory/2017-04-10/
 AdaptivePlugin                # SECURITY-457
-artifactdeployer              # SECURITY-294
 build-flow-plugin             # SECURITY-293
 cas1                          # SECURITY-491
 cvs-tag                       # SECURITY-459

--- a/src/main/resources/warnings.json
+++ b/src/main/resources/warnings.json
@@ -353,7 +353,8 @@
     "url": "https://jenkins.io/security/advisory/2017-04-10/",
     "versions": [
       {
-        "pattern": ".*"
+        "lastVersion": "0.33",
+        "pattern": "0[.].*"
       }
     ]
   },


### PR DESCRIPTION
Restore Artifact Deployer plugin distribution for version 1.2 or higher