### PR TITLE
Ignoring a plugin because it was renamed (artifactId)

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -20,6 +20,7 @@ cifs                             # Superseded by Publish Over CIFS Plugin -- htt
 cloudbees-deployer-plugin        # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Cloudbees+Deployer+Plugin
 cloudbees-enterprise-plugins     # Unsupported and retracted by service provider -- https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Jenkins+Enterprise
 cloudbees-registration           # "This feature is no longer relevant." -- https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Registration+Plugin
+cloudbees-disk-usage-simple-plugin # renamed to cloudbees-disk-usage-simple several years ago
 ColumnPack-plugin                # renamed to ColumnsPlugin
 ConfigurationSlicing             # renamed into configurationslicing, and this double causes a check out problem on Windows
 copyarchiver                     # superseded by ArtifactDeployer Plugin  -- https://wiki.jenkins-ci.org/display/JENKINS/CopyArchiver+Plugin


### PR DESCRIPTION
I should have been done this few years ago when I did [this change](https://github.com/jenkinsci/cloudbees-disk-usage-simple-plugin/commit/8857d66b83aceb0cccfd8a10878db58d427eeb72).