### PR TITLE
[INFRA-1482] Drop support for historically beta-only plugins

### DIFF
--- a/src/main/java/org/jvnet/hudson/update_center/AlphaBetaOnlyRepository.java
+++ b/src/main/java/org/jvnet/hudson/update_center/AlphaBetaOnlyRepository.java
@@ -50,7 +50,7 @@ public class AlphaBetaOnlyRepository extends MavenRepository {
 
             for (Iterator<Entry<VersionNumber, HPI>> itr = h.artifacts.entrySet().iterator(); itr.hasNext();) {
                 Entry<VersionNumber, HPI> e =  itr.next();
-                if (isAlphaOrBeta(e.getValue())^negative)
+                if (e.getValue().isAlphaOrBeta()^negative)
                     continue;
                 itr.remove();
             }
@@ -62,25 +62,8 @@ public class AlphaBetaOnlyRepository extends MavenRepository {
         return r;
     }
 
-    private boolean isAlphaOrBeta(HPI v) {
-        if (HISTORICALLY_BETA_ONLY.contains(v.artifact.artifactId))
-            return false;
-        return v.isAlphaOrBeta();
-    }
-
-
     @Override
     public File resolve(ArtifactInfo a, String type, String classifier) throws AbstractArtifactResolutionException {
         return base.resolve(a, type, classifier);
     }
-
-    /**
-     * Historically these plugins have never released non-experimental versions,
-     * so we always count them as releases even though they have alpha/beta in the version number
-     */
-    private static final Set<String> HISTORICALLY_BETA_ONLY = new HashSet<String>(Arrays.asList(
-            "BlazeMeterJenkinsPlugin",
-            "heroku-jenkins-plugin",
-            "deployit-plugin"
-            ));
 }


### PR DESCRIPTION
Basically revert https://github.com/jenkins-infra/backend-update-center2/commit/0152b87eb88a4acb0a4bd0b4e498be643923365e

Blocks (sort of) https://github.com/jenkins-infra/jenkins.io/pull/1335

`BlazeMeterJenkinsPlugin` and `deployit-plugin` have long been released, only `heroku-jenkins-plugin` will be removed by this unless/until it gets a proper release.

TBH, given https://plugins.jenkins.io/heroku-jenkins-plugin stats (~130 installs, no release since 2012) and https://github.com/heroku/heroku-jenkins-plugin/commit/348e94b6932eae7da5e73615d9f6130f171311ae (deprecated two years ago), this doesn't look like something we need to keep a workaround for indefinitely.

Pinging @ryanbrainard the last known maintainer to give a chance to respond (or just release a non-beta version of the plugin).