### PR TITLE
[JENKINS-49323] Add cloudbees-jenkins-advisor to the blacklist

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -19,6 +19,7 @@ ChatRoom                         # junk plugin; developer has been banned
 cifs                             # Superseded by Publish Over CIFS Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/CIFS-Publisher+Plugin
 cloudbees-deployer-plugin        # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Cloudbees+Deployer+Plugin
 cloudbees-enterprise-plugins     # Unsupported and retracted by service provider -- https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Jenkins+Enterprise
+cloudbees-jenkins-advisor        # Service discontinued -- https://wiki.jenkins.io/display/JENKINS/CloudBees+Jenkins+Advisor+Plugin
 cloudbees-registration           # "This feature is no longer relevant." -- https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Registration+Plugin
 cloudbees-disk-usage-simple-plugin # renamed to cloudbees-disk-usage-simple several years ago
 ColumnPack-plugin                # renamed to ColumnsPlugin


### PR DESCRIPTION
[JENKINS-49323](https://issues.jenkins-ci.org/browse/JENKINS-49323)

CloudBees is ending the CloudBees Jenkins Advisor service.  We need to remove the plugin from the update center.  Current users will be notified about the service ending.