### PR TITLE
blacklist qtest plugin v1.2.0 because it's draft release

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -147,6 +147,7 @@ rebuild-1.2               # release troubles.. skip these
 rebuild-1.3               # ??
 ruby-runtime-0.13         # JENKINS-37353, JENKINS-37771 and JENKINS-38145
 jira-2.5.1                # JENKINS-48357 - binary compatibility issues
+qtest-1.2.0               # draft release and not the latest release
 
 # rogue releases with unknown source
 ez-templates-1.0.0


### PR DESCRIPTION
blacklist qtest plugin v1.2.0 because it's draft release and not the latest release