### PR TITLE
Simplify plugin display names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,11 @@
       <version>1.3.2</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.7</version>
+    </dependency>
+    <dependency>
       <groupId>args4j</groupId>
       <artifactId>args4j</artifactId>
       <version>${args4j.version}</version>

--- a/src/main/java/org/jvnet/hudson/update_center/Plugin.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Plugin.java
@@ -399,7 +399,7 @@ public class Plugin {
         name = StringUtils.removeEndIgnoreCase(name, " Jenkins Plugin");
         name = StringUtils.removeEndIgnoreCase(name, " Plugin");
         name = StringUtils.removeEndIgnoreCase(name, " Plug-In");
-        name = name.replaceAll("[ -.!]+$", ""); // remove trailing punctuation e.g. for 'Acme Foo - Jenkins Plugin'
+        name = name.replaceAll("[- .!]+$", ""); // remove trailing punctuation e.g. for 'Acme Foo - Jenkins Plugin'
         return name;
     }
 

--- a/src/main/java/org/jvnet/hudson/update_center/Plugin.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Plugin.java
@@ -394,6 +394,7 @@ public class Plugin {
             title = StringUtils.removeEnd(title, " Plug-In");
             title = StringUtils.removeEnd(title, " Plug-in");
             title = StringUtils.removeEnd(title, " plug-in");
+            title = StringUtils.removeEnd(title, " Jenkins");
         }
         return title;
     }

--- a/src/main/java/org/jvnet/hudson/update_center/Plugin.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Plugin.java
@@ -386,15 +386,16 @@ public class Plugin {
         if (title == null) {
             title = artifactId;
         } else {
-            title = StringUtils.removeStart(title.trim(), "Jenkins ");
-            title = StringUtils.removeStart(title, "Hudson ");
-            title = StringUtils.removeEnd(title, " for Jenkins");
-            title = StringUtils.removeEnd(title, " Plugin");
-            title = StringUtils.removeEnd(title, " plugin");
-            title = StringUtils.removeEnd(title, " Plug-In");
-            title = StringUtils.removeEnd(title, " Plug-in");
-            title = StringUtils.removeEnd(title, " plug-in");
-            title = StringUtils.removeEnd(title, " Jenkins");
+            title = StringUtils.removeStart(title.trim(), "Jenkins");
+            title = StringUtils.removeStart(title.trim(), "Hudson");
+            title = StringUtils.removeEnd(title.trim(), "for Jenkins");
+            title = StringUtils.removeEnd(title.trim(), "Plugin");
+            title = StringUtils.removeEnd(title.trim(), "plugin");
+            title = StringUtils.removeEnd(title.trim(), "Plug-In");
+            title = StringUtils.removeEnd(title.trim(), "Plug-in");
+            title = StringUtils.removeEnd(title.trim(), "plug-in");
+            title = StringUtils.removeEnd(title.trim(), "Jenkins");
+            title = title.replaceAll("[ -.!]+$", ""); // remove trailing punctuation e.g. for 'Acme Foo - Jenkins Plugin'
         }
         return title;
     }

--- a/src/main/java/org/jvnet/hudson/update_center/Plugin.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Plugin.java
@@ -23,11 +23,12 @@
  */
 package org.jvnet.hudson.update_center;
 
+import com.google.common.annotations.VisibleForTesting;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.methods.GetMethod;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.dom4j.Document;
 import org.dom4j.DocumentException;
 import org.dom4j.DocumentFactory;
@@ -38,7 +39,6 @@ import org.sonatype.nexus.index.ArtifactInfo;
 
 import java.io.IOException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -386,18 +386,21 @@ public class Plugin {
         if (title == null) {
             title = artifactId;
         } else {
-            title = StringUtils.removeStart(title.trim(), "Jenkins");
-            title = StringUtils.removeStart(title.trim(), "Hudson");
-            title = StringUtils.removeEnd(title.trim(), "for Jenkins");
-            title = StringUtils.removeEnd(title.trim(), "Plugin");
-            title = StringUtils.removeEnd(title.trim(), "plugin");
-            title = StringUtils.removeEnd(title.trim(), "Plug-In");
-            title = StringUtils.removeEnd(title.trim(), "Plug-in");
-            title = StringUtils.removeEnd(title.trim(), "plug-in");
-            title = StringUtils.removeEnd(title.trim(), "Jenkins");
-            title = title.replaceAll("[ -.!]+$", ""); // remove trailing punctuation e.g. for 'Acme Foo - Jenkins Plugin'
+            title = simplifyPluginName(title);
         }
         return title;
+    }
+
+    @VisibleForTesting
+    public static String simplifyPluginName(String name) {
+        name = StringUtils.removeStart(name, "Jenkins ");
+        name = StringUtils.removeStart(name, "Hudson ");
+        name = StringUtils.removeEndIgnoreCase(name, " for Jenkins");
+        name = StringUtils.removeEndIgnoreCase(name, " Jenkins Plugin");
+        name = StringUtils.removeEndIgnoreCase(name, " Plugin");
+        name = StringUtils.removeEndIgnoreCase(name, " Plug-In");
+        name = name.replaceAll("[ -.!]+$", ""); // remove trailing punctuation e.g. for 'Acme Foo - Jenkins Plugin'
+        return name;
     }
 
     public JSONObject toJSON() throws IOException {

--- a/src/main/java/org/jvnet/hudson/update_center/Plugin.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Plugin.java
@@ -27,6 +27,7 @@ import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.commons.lang.StringUtils;
 import org.dom4j.Document;
 import org.dom4j.DocumentException;
 import org.dom4j.DocumentFactory;
@@ -379,11 +380,20 @@ public class Plugin {
         return labels.split("\\s+");
     }
 
-    /** @return The plugin name defined in the POM &lt;name>; falls back to the wiki page title, then artifact ID. */
+    /** @return The plugin name defined in the POM &lt;name> modified by simplication rules (no 'Jenkins', no 'Plugin'); then artifact ID. */
     public String getName() throws IOException {
         String title = selectSingleValue(getPom(), "/project/name");
         if (title == null) {
             title = artifactId;
+        } else {
+            title = StringUtils.removeStart(title.trim(), "Jenkins ");
+            title = StringUtils.removeStart(title, "Hudson ");
+            title = StringUtils.removeEnd(title, " for Jenkins");
+            title = StringUtils.removeEnd(title, " Plugin");
+            title = StringUtils.removeEnd(title, " plugin");
+            title = StringUtils.removeEnd(title, " Plug-In");
+            title = StringUtils.removeEnd(title, " Plug-in");
+            title = StringUtils.removeEnd(title, " plug-in");
         }
         return title;
     }

--- a/src/test/java/org/jvnet/hudson/update_center/PluginTest.java
+++ b/src/test/java/org/jvnet/hudson/update_center/PluginTest.java
@@ -36,6 +36,7 @@ public class PluginTest extends TestCase {
         assertSimpleName("Smart Jenkins", "Smart Jenkins");
 //        assertSimpleName("Testdroid Plugin for CI", "Testdroid");
         assertSimpleName("Use Dumpling from Jenkins groovy scripts", "Use Dumpling from Jenkins groovy scripts");
+        assertSimpleName("JavaScript GUI Lib: jQuery bundles (jQuery and jQuery UI)", "JavaScript GUI Lib: jQuery bundles (jQuery and jQuery UI)");
     }
 
     private static void assertSimpleName(String original, String expected) {

--- a/src/test/java/org/jvnet/hudson/update_center/PluginTest.java
+++ b/src/test/java/org/jvnet/hudson/update_center/PluginTest.java
@@ -1,0 +1,45 @@
+package org.jvnet.hudson.update_center;
+
+import junit.framework.TestCase;
+
+public class PluginTest extends TestCase {
+
+    public void testSimplifyPluginName() {
+        assertSimpleName("AWS Batch Plugin", "AWS Batch");
+        assertSimpleName("AWS CodeDeploy Plugin for Jenkins", "AWS CodeDeploy");
+        assertSimpleName("All changes plugin", "All changes");
+        assertSimpleName("Chef Sinatra Jenkins plugin", "Chef Sinatra");
+//        assertSimpleName("ClearCase UCM Plugin!", "ClearCase UCM");
+//        assertSimpleName("CocoaPods Jenkins Integration", "CocoaPods");
+//        assertSimpleName("Computer-queue-plugin", "Computer-queue");
+//        assertSimpleName("Coverage/Complexity Scatter Plot PlugIn", "Coverage/Complexity Scatter Plot");
+        assertSimpleName("Cucumber json test reporting.", "Cucumber json test reporting");
+        assertSimpleName("DaticalDB4Jenkins", "DaticalDB4Jenkins");
+        assertSimpleName("Dynamic Extended Choice Parameter Plug-In", "Dynamic Extended Choice Parameter");
+        assertSimpleName("ElasticBox Jenkins Kubernetes CI/CD Plug-in", "ElasticBox Jenkins Kubernetes CI/CD");
+//        assertSimpleName("emotional-jenkins-plugin", "emotional-jenkins");
+        assertSimpleName("Google Deployment Manager Jenkins Plugin", "Google Deployment Manager");
+        assertSimpleName("Hudson Blame Subversion Plug-in", "Blame Subversion");
+        assertSimpleName("Hudson global-build-stats plugin", "global-build-stats");
+        assertSimpleName("IBM Content Navigator remote plug-in reloader", "IBM Content Navigator remote plug-in reloader");
+//        assertSimpleName("Inedo BuildMaster Plugin.", "Inedo BuildMaster");
+        assertSimpleName("Jenkins AccuRev plugin", "AccuRev");
+        assertSimpleName("Jenkins Clone Workspace SCM Plug-in", "Clone Workspace SCM");
+        assertSimpleName("Jenkins Harvest SCM", "Harvest SCM");
+        assertSimpleName("Jenkins Self-Organizing Swarm Plug-in Modules", "Self-Organizing Swarm Plug-in Modules");
+        assertSimpleName("JenkinsLint Plugin", "JenkinsLint");
+//        assertSimpleName("jenkins-cloudformation-plugin", "jenkins-cloudformation");
+//        assertSimpleName("Mail Commander Plugin for Jenkins-ci", "Mail Commander");
+//        assertSimpleName("Maven Metadata Plugin for Jenkins CI server", "Maven Metadata");
+        assertSimpleName("PTC Integrity CM - Jenkins Plugin", "PTC Integrity CM");
+        assertSimpleName("Plugin Usage - Plugin", "Plugin Usage");
+        assertSimpleName("Smart Jenkins", "Smart Jenkins");
+//        assertSimpleName("Testdroid Plugin for CI", "Testdroid");
+        assertSimpleName("Use Dumpling from Jenkins groovy scripts", "Use Dumpling from Jenkins groovy scripts");
+    }
+
+    private static void assertSimpleName(String original, String expected) {
+        assertEquals(expected, Plugin.simplifyPluginName(original));
+    }
+
+}


### PR DESCRIPTION
'Hudson', 'Jenkins', and 'Plugin' (or 'Plug-In') is redundant, so
remove them.

@slide @batmat @orrc WDYT?